### PR TITLE
Pass filename to HDF5 file with Hamiltonian constructor

### DIFF
--- a/CheMPS2/Hamiltonian.cpp
+++ b/CheMPS2/Hamiltonian.cpp
@@ -59,14 +59,14 @@ CheMPS2::Hamiltonian::Hamiltonian(const int Norbitals, const int nGroup, const i
 
 }
 
-CheMPS2::Hamiltonian::Hamiltonian(const string filename){
+CheMPS2::Hamiltonian::Hamiltonian(const string filename, bool h5file){
 
-   if ( filename.compare("LOADH5") == 0 ){
-      CreateAndFillFromH5();
-   } else {
+   if ( filename.compare("LOADH5") == 0 )
+      CreateAndFillFromH5(CheMPS2::HAMILTONIAN_ParentStorageName);
+   else if (h5file)
+      CreateAndFillFromH5(filename);
+   else 
       CreateAndFillFromPsi4dump( filename );
-   }
-   
 }
 
 CheMPS2::Hamiltonian::~Hamiltonian(){
@@ -230,10 +230,10 @@ void CheMPS2::Hamiltonian::read(){
 
 }
 
-void CheMPS2::Hamiltonian::CreateAndFillFromH5(){
+void CheMPS2::Hamiltonian::CreateAndFillFromH5(const string filename){
 
    //The hdf5 file
-   hid_t file_id = H5Fopen(CheMPS2::HAMILTONIAN_ParentStorageName.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+   hid_t file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
       
       //The data
       hid_t group_id = H5Gopen(file_id, "/Data",H5P_DEFAULT);

--- a/CheMPS2/include/Hamiltonian.h
+++ b/CheMPS2/include/Hamiltonian.h
@@ -61,8 +61,9 @@ namespace CheMPS2{
          Hamiltonian(const int Norbitals, const int nGroup, const int * OrbIrreps);
          
          //! Constructor which loads a Hamiltonian from disk
-         /** \param filename If the filename is "LOADH5" then the Hamiltonian in HDF5 format is loaded; else a Psi4 text dump in "filename" will be loaded. The text dump can be generated with the plugin psi4plugins/mointegrals.cc_PRINT. An HDF5 dump can be generated with the plugin psi4plugins/mointegrals.cc_SAVEHAM; or by (1) creating a Hamiltonian with the other constructor, (2) filling it with setEconst(), setTmat() and setVmat(), and (3) calling save(). */
-         Hamiltonian(const string filename="LOADH5");
+         /** \param filename If the filename is "LOADH5" then the Hamiltonian in HDF5 format is loaded; else a Psi4 text dump in "filename" will be loaded. The text dump can be generated with the plugin psi4plugins/mointegrals.cc_PRINT. An HDF5 dump can be generated with the plugin psi4plugins/mointegrals.cc_SAVEHAM; or by (1) creating a Hamiltonian with the other constructor, (2) filling it with setEconst(), setTmat() and setVmat(), and (3) calling save(). 
+          *  \param h5file set to true of the file where filename points to is a HDF5 file */
+         Hamiltonian(const string filename="LOADH5", bool h5file=false);
          
          //! Destructor
          virtual ~Hamiltonian();
@@ -160,7 +161,7 @@ namespace CheMPS2{
          double Econst;
          
          //If filename=="LOADH5" in Hamiltonian::Hamiltonian then the HDF5 Hamiltonian is loaded
-         void CreateAndFillFromH5();
+         void CreateAndFillFromH5(const string filename);
          
          //If filename!="LOADH5" in Hamiltonian::Hamiltonian then a Psi4 dump in the file with name "filename" is loaded
          void CreateAndFillFromPsi4dump(const string filename);


### PR DESCRIPTION
I want to be able to do:

```
Hamiltonian("file.h5", true);
```

aka, not necessarily read the filename from `CheMPS2::HAMILTONIAN_ParentStorageName`
