### PR TITLE
link libs, lapack detection minor CMake fixes

### DIFF
--- a/CMake/FindTargetLAPACK.cmake
+++ b/CMake/FindTargetLAPACK.cmake
@@ -14,6 +14,12 @@
 #   LAPACK_FOUND
 #   LAPACK_LIBRARIES
 #
+# In order of decreasing precedence, this module returns in a target ``tgt::lapack``
+#  (1) the libraries passed through CMake variable LAPACK_LIBRARIES,
+#  (2) the libraries defined in a detectable TargetLAPACKConfig.cmake file
+#      (skip via DISABLE_FIND_PACKAGE_TargetLAPACK), or
+#  (3) the libraries detected by the usual FindLAPACK.cmake module.
+#
 
 set(PN TargetLAPACK)
 
@@ -27,7 +33,9 @@ if (LAPACK_LIBRARIES)
     set_property (TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
 else()
     # 2nd precedence - target already prepared and findable in TargetLAPACKConfig.cmake
-    find_package (TargetLAPACK QUIET CONFIG)
+    if (NOT "${DISABLE_FIND_PACKAGE_${PN}}")
+        find_package (TargetLAPACK QUIET CONFIG)
+    endif()
     if (TARGET tgt::lapack)
         if (NOT ${PN}_FIND_QUIETLY)
             message (STATUS "TargetLAPACKConfig detected.")

--- a/CheMPS2/CMakeLists.txt
+++ b/CheMPS2/CMakeLists.txt
@@ -72,8 +72,8 @@ endif()
 
 if (NOT STATIC_ONLY)
     add_library           (chemps2-shared SHARED  $<TARGET_OBJECTS:chemps2-base>)
-    target_link_libraries (chemps2-shared PRIVATE ${LIBC_INTERJECT}
-                                                  tgt::lapack
+    target_link_libraries (chemps2-shared PRIVATE ${LIBC_INTERJECT})
+    target_link_libraries (chemps2-shared PUBLIC  tgt::lapack
                                                   tgt::hdf5)
     set_target_properties (chemps2-shared PROPERTIES SOVERSION ${CheMPS2_LIB_SOVERSION}
                                                      MACOSX_RPATH ON
@@ -83,8 +83,8 @@ endif()
 
 if (NOT SHARED_ONLY)
     add_library           (chemps2-static STATIC  $<TARGET_OBJECTS:chemps2-base>)
-    target_link_libraries (chemps2-static PRIVATE ${LIBC_INTERJECT}
-                                                  tgt::lapack
+    target_link_libraries (chemps2-static PRIVATE ${LIBC_INTERJECT})
+    target_link_libraries (chemps2-static PUBLIC  tgt::lapack
                                                   tgt::hdf5)
     set_target_properties (chemps2-static PROPERTIES OUTPUT_NAME "chemps2"
                                                      EXPORT_NAME "chemps2")


### PR DESCRIPTION
Hi @SebWouters, about time for my annual build tweaks PR.

- [x] I've suspected for a bit that I was [wrong here](https://github.com/SebWouters/CheMPS2/pull/56#issuecomment-257135286) so correcting that by properly declaring HDF5 and LAPACK to be needed by projects linking `libchemps2`.
- [x] Other change, I've never needed for CheMPS2, but in the case where building this project and `tgt::lapack` is detectable but you don't want to use it, nor you want to define the LAPACK_LIBRARIES explicitly, this lets you skip to the 3rd precedence, ordinary `find_package(LAPACK)` detection.